### PR TITLE
use SO_KEEPALIVE to prevent disconnections under NAT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: perl
+dist: trusty # to support older perls as Xenial only supports 5.22+
 perl:
   - "5.26"
   - "5.24"

--- a/lib/AnyEvent/Gearman/Connection.pm
+++ b/lib/AnyEvent/Gearman/Connection.pm
@@ -1,6 +1,7 @@
 package AnyEvent::Gearman::Connection;
 use Any::Moose;
 use Scalar::Util 'weaken';
+use Socket;
 
 use AnyEvent::Socket;
 use AnyEvent::Handle;
@@ -88,7 +89,8 @@ sub connect {
         my ($fh) = @_;
 
         if ($fh) {
-            my $handle = AnyEvent::Handle->new(
+	     setsockopt($fh, SOL_SOCKET, SO_KEEPALIVE, 1) or warn "setsockopt() failed: $!";
+	     my $handle = AnyEvent::Handle->new(
                 fh       => $fh,
                 on_read  => sub { $self->process_packet },
                 on_error => sub {


### PR DESCRIPTION
Fixes a defect when calling add_task() on idle connections
neither actually send any data, so the client became "stuck".

If a client is behind a NAT and doesn't send any data,
after some 2 hours the connection silently disappears from
NAT tables due to timeout. However, Gearman (and system TCP
stack) still thinks it's connected. So when you add a task
after a long timeout, the sender thinks that connection is open,
but NAT thinks the packet is spoofed, so it ignores it.